### PR TITLE
Fix board to use statefulsets instead of deployments

### DIFF
--- a/cplace_deployments.json
+++ b/cplace_deployments.json
@@ -1,4 +1,34 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "6.7.0-6ca813bapre"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -18,13 +48,13 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 9,
-  "iteration": 1588590505587,
+  "id": null,
+  "iteration": 1589283489933,
   "links": [],
   "panels": [
     {
       "columns": [],
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fontSize": "100%",
       "gridPos": {
         "h": 9,
@@ -199,7 +229,7 @@
       ],
       "targets": [
         {
-          "expr": "kube_deployment_labels{namespace=~\"$namespace\", label_app_kubernetes_io_name=~\"cplace\"} * on(deployment) group_left(Value) (kube_deployment_created{namespace=~\"$namespace\"} * 1000)",
+          "expr": "kube_statefulset_labels{namespace=~\"$namespace\", label_app_kubernetes_io_name=~\"cplace\"} * on(statefulset) group_left(Value) (kube_statefulset_created{namespace=~\"$namespace\"} * 1000)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -225,12 +255,8 @@
     "list": [
       {
         "allValue": null,
-        "current": {
-          "selected": true,
-          "text": "qa",
-          "value": "qa"
-        },
-        "datasource": "Prometheus",
+        "current": {},
+        "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(kube_pod_info, namespace)",
         "hide": 0,
         "includeAll": false,
@@ -252,7 +278,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-7d",
     "to": "now"
   },
   "timepicker": {
@@ -272,5 +298,5 @@
   "timezone": "",
   "title": "cplace deployments",
   "uid": "CqnGlH6Wz",
-  "version": 20
+  "version": 21
 }


### PR DESCRIPTION
Just a small fix to use statefulsets. After we changed to statefulsets for cplace the board did not work anymore because it was looking for deployments in Prometheus.